### PR TITLE
Refactor axios setup into axiosConfig with base and authenticated instances

### DIFF
--- a/client/src/services/auth.js
+++ b/client/src/services/auth.js
@@ -1,24 +1,23 @@
-import axios from 'axios'
-axios.defaults.withCredentials = true;
-const BASE_URL = 'http://localhost:5000/api/'
+// import axios from 'axios'
+// axios.defaults.withCredentials = true;
+import { ThrowErorr } from '../utils/ErrorUtils';
+import { baseAxios } from '../utils/AxiosConfig';
 
-//axios default
 export const loginService = async(user)=>{
     try{
-        const response = await axios.post(BASE_URL + '/login', user);
+        const response = await baseAxios.post('/login', user);
         return response;
     }
     catch(err){
-        console.error(err);
+        ThrowErorr(err);
     }
 }
 
-//axios default
 export const registerService = async(userFormData) =>{
     try{
-        const response = await axios({
+        const response = await baseAxios({
             method: 'post',
-            url: 'http://localhost:5000/api/register',
+            url: '/register',
             data: userFormData,
             headers: {
                 'Content-Type': `multipart/form-data`,
@@ -27,12 +26,11 @@ export const registerService = async(userFormData) =>{
         return response;
     }
     catch(err){
-        console.error(err);
+        ThrowErorr(err);
     }
 }
 
-//axios default
-export const logutService = async() =>{
-    await axios.get('http://localhost:5000/api/logout');
+export const logoutService = async() =>{
+    await baseAxios.get('/logout');
 }
 

--- a/client/src/services/chat.js
+++ b/client/src/services/chat.js
@@ -1,11 +1,10 @@
 import { ThrowErorr } from '../utils/ErrorUtils'
-const BASE_URL = 'http://localhost:5000/api/'
+import { authenticatedAxios } from '../utils/AxiosConfig'
 
-import { axiosSession } from '../utils/AxiosInterceptors'
 
 export const getUserRooms = async(username) =>{
     try{
-        const result = await axiosSession.get(BASE_URL + `chat/rooms/${username}`)
+        const result = await authenticatedAxios.get(`/chat/rooms/${username}`)
         const data = result.data;
         return data;
     }
@@ -16,7 +15,7 @@ export const getUserRooms = async(username) =>{
 
 export const getMessagesByRoomID = async(roomID) =>{
     try{
-        const result = await axiosSession.get(BASE_URL + `chat/room/${roomID}/messages?offset=0&size=16`)
+        const result = await authenticatedAxios.get(`/chat/room/${roomID}/messages?offset=0&size=16`)
         const messages = result.data;
         return messages;
     }
@@ -27,7 +26,7 @@ export const getMessagesByRoomID = async(roomID) =>{
 
 export const getMoreMessagesByRoomID = async(roomID, pageNumber) =>{
     try{
-        const result = await axiosSession.get(BASE_URL + `chat/room/message/${roomID}/${pageNumber}`)
+        const result = await authenticatedAxios.get(`/chat/room/message/${roomID}/${pageNumber}`)
         const messages = result.data;
         return messages;
     }
@@ -38,7 +37,7 @@ export const getMoreMessagesByRoomID = async(roomID, pageNumber) =>{
 
 export const deleteRoom = async(roomID) =>{
     try{
-        const result = await axiosSession.delete(BASE_URL +`chat/room/delete/${roomID}`);
+        const result = await authenticatedAxios.delete(`/chat/room/delete/${roomID}`);
         return result.data;
     }
     catch(err){
@@ -48,7 +47,7 @@ export const deleteRoom = async(roomID) =>{
 
 export const addUserToRoom = async(roomInfo) =>{
     try{
-        const result = await axiosSession.post( BASE_URL + 'chat/room/addUser',roomInfo);
+        const result = await authenticatedAxios.post('/chat/room/addUser',roomInfo);
         return result;
     }
     catch(err){
@@ -58,7 +57,7 @@ export const addUserToRoom = async(roomInfo) =>{
 
 export const removeUserFromGroup = async(roomInfo) =>{
     try{
-        const result = await axiosSession.delete(BASE_URL + `chat/room/removeUser/${roomInfo.roomID}/${roomInfo.username}`);
+        const result = await authenticatedAxios.delete(`/chat/room/removeUser/${roomInfo.roomID}/${roomInfo.username}`);
         return result;
     }
     catch(err){
@@ -68,7 +67,7 @@ export const removeUserFromGroup = async(roomInfo) =>{
 
 export const sendMessageToUser = async(messageObj) =>{
     try{
-        const result = await axiosSession.post(BASE_URL + 'chat/room/message', messageObj);
+        const result = await authenticatedAxios.post('/chat/room/message', messageObj);
         return result.data;
     }
     catch(err){
@@ -78,7 +77,7 @@ export const sendMessageToUser = async(messageObj) =>{
 
 export const getOnlineUsers = async(userID) =>{
     try{
-        const result = await axiosSession.get(BASE_URL + `chat/room/onlineUsers/${userID}`);
+        const result = await authenticatedAxios.get(`/chat/room/onlineUsers/${userID}`);
         return result.data;
     }
     catch(err){
@@ -88,7 +87,7 @@ export const getOnlineUsers = async(userID) =>{
 
 export const getFirstRoomID = async(userID) =>{
     try{
-        const result = await axiosSession.get(BASE_URL + `chat/room/firstRoom/${userID}`);
+        const result = await authenticatedAxios.get(`/chat/room/firstRoom/${userID}`);
         return result.data;
     }
     catch(err){
@@ -98,7 +97,7 @@ export const getFirstRoomID = async(userID) =>{
 
 export const getFriendsList = async(userID) =>{
     try{
-        const result = await axiosSession.get(BASE_URL + `chat/room/friends/${userID}`);
+        const result = await authenticatedAxios.get(`/chat/room/friends/${userID}`);
         return result.data;
     }
     catch(err){
@@ -109,7 +108,7 @@ export const getFriendsList = async(userID) =>{
 
 export const getAllUnreadMessages = async(username) =>{
     try{
-        const result = await axiosSession.get(BASE_URL + `chat/room/unread/${username}`);
+        const result = await authenticatedAxios.get(`/chat/room/unread/${username}`);
         return result.data;
     }
     catch(err){
@@ -119,7 +118,7 @@ export const getAllUnreadMessages = async(username) =>{
 
 export const getUnreadTotalCountMessages = async(userID) =>{
     try{
-        const result = await axiosSession.get(BASE_URL + `chat/room/unread/count/${userID}`);
+        const result = await authenticatedAxios.get(`/chat/room/unread/count/${userID}`);
         return result.data;
     }
     catch(err){
@@ -129,7 +128,7 @@ export const getUnreadTotalCountMessages = async(userID) =>{
 
 export const resetUnreadMessagesCount = async(roomID, userID) =>{
     try{
-        const result = await axiosSession.delete(BASE_URL + `chat/room/unread/delete/${roomID}/${userID}`);
+        const result = await authenticatedAxios.delete(`/chat/room/unread/delete/${roomID}/${userID}`);
         return result.data;
     }
     catch(err){
@@ -139,7 +138,7 @@ export const resetUnreadMessagesCount = async(roomID, userID) =>{
 
 export const resetUsersUnreadMessagesCount = async(roomID, clientID) =>{
     try{
-        const result = await axiosSession.delete(BASE_URL + `chat/room/unread/delete/all/${roomID}/${clientID}`);
+        const result = await authenticatedAxios.delete(`/chat/room/unread/delete/all/${roomID}/${clientID}`);
         return result.data;
     }
     catch(err){
@@ -149,7 +148,7 @@ export const resetUsersUnreadMessagesCount = async(roomID, clientID) =>{
 
 export const forwardUnreadMessagesFromOldToNewRoom = async(roomData) =>{
     try{
-        const result = await axiosSession.put(BASE_URL + `chat/room/unread/forward/`, roomData);
+        const result = await authenticatedAxios.put(`/chat/room/unread/forward/`, roomData);
         return result.data;
     }
     catch(err){

--- a/client/src/services/client.js
+++ b/client/src/services/client.js
@@ -1,13 +1,9 @@
-// import axios from 'axios'
-// axios.defaults.withCredentials = true;
 import { ThrowErorr } from '../utils/ErrorUtils'
-const BASE_URL = 'http://localhost:5000/api/'
-
-import { axiosSession } from '../utils/AxiosInterceptors'
+import { authenticatedAxios } from '../utils/AxiosConfig';
 
 export const getUserData = async() =>{
     try{
-        const result = await axiosSession.get(BASE_URL + `clients/info`)
+        const result = await authenticatedAxios.get(`/clients/info`)
         const client_data = result.data;
         return client_data;
     }
@@ -18,7 +14,7 @@ export const getUserData = async() =>{
 
 export const updateClient = async(formData) =>{
     try{
-        await axiosSession.put(BASE_URL + `clients/update/`, formData, {
+        await authenticatedAxios.put(`/clients/update/`, formData, {
             headers: {
                 'Content-Type': 'multipart/form-data',
                 // 'Content-Type': 'application/json',
@@ -36,17 +32,16 @@ export const updateClient = async(formData) =>{
 export const deleteComment = async(client_username, comment_id) =>{
     try{
         const params = {client_username: client_username, comment_id: comment_id}
-        await axiosSession.delete(BASE_URL + `clients/comment`, {params})
+        await authenticatedAxios.delete(`/clients/comment`, {params})
     }
     catch(err){
         ThrowErorr(err);
     }
 }
 
-//axios default
 export const getRecommended= async(username) =>{
     try{
-        const result = await axiosSession.get(BASE_URL + `clients/recommended/${username}`);
+        const result = await authenticatedAxios.get(`/clients/recommended/${username}`);
         const recommendedData = result.data;
         return recommendedData;
     }

--- a/client/src/services/houseworker.js
+++ b/client/src/services/houseworker.js
@@ -1,13 +1,10 @@
 import axios from 'axios'
 import { ThrowErorr } from '../utils/ErrorUtils';
-const BASE_URL = 'http://localhost:5000/api/'
+import { baseAxios, authenticatedAxios } from '../utils/AxiosConfig';
 
-import { axiosSession } from '../utils/AxiosInterceptors';
-
-//username is included in the request and taken from session
 export const getUserData = async() =>{
     try{
-        const result = await axiosSession.get(BASE_URL + `houseworker/info`);
+        const result = await authenticatedAxios.get(`/houseworker/info`);
         const houseworkerResult = result.data;
         return houseworkerResult;
     }
@@ -16,10 +13,9 @@ export const getUserData = async() =>{
     }
 }
 
-//axios default
 export const getHouseworkers = async() =>{
     try{
-        const result = await axios.get(BASE_URL + `houseworker`);
+        const result = await baseAxios.get(`/houseworker`);
         const houseworkerResult = result.data;
         return houseworkerResult;
     }
@@ -30,7 +26,7 @@ export const getHouseworkers = async() =>{
 
 export const getHouseworkersCount = async() =>{
     try{
-        const result = await axiosSession.get(BASE_URL + `houseworker/count`)
+        const result = await authenticatedAxios.get(`/houseworker/count`)
         const count = result.data;
         return count;
     }
@@ -41,10 +37,9 @@ export const getHouseworkersCount = async() =>{
 
 export const updateHouseworker = async(newData) =>{
     try{
-        // await axiosSession.post( BASE_URL + `houseworker/update/`, newData);
-        await axiosSession({
+        await authenticatedAxios({
             method: 'post',
-            url: 'http://localhost:5000/api/houseworkerupdate',
+            url: '/update',
             data: newData,
             headers: {
                 'Content-Type': `multipart/form-data`,
@@ -58,7 +53,7 @@ export const updateHouseworker = async(newData) =>{
 
 export const updateProfessionWorkingHour = async(profession, working_hour) =>{
     try{
-        await axiosSession.put( BASE_URL + `houseworker/professions/update/`, {profession, working_hour});
+        await authenticatedAxios.put(`/houseworker/professions/update/`, {profession, working_hour});
     }
     catch(err){
         ThrowErorr(err);
@@ -68,7 +63,7 @@ export const updateProfessionWorkingHour = async(profession, working_hour) =>{
 //user of authenticated user(username taken from  session data)
 export const getAuthenticatedUserComments = async(pageNumber) =>{
     try{
-        const result = await axiosSession.get(BASE_URL + `houseworker/ourcomments/${pageNumber}`);
+        const result = await authenticatedAxios.get(`/houseworker/ourcomments/${pageNumber}`);
         const comms = result.data;
         return comms;
     }
@@ -79,7 +74,7 @@ export const getAuthenticatedUserComments = async(pageNumber) =>{
 
 export const getComments = async(username, pageNumber) =>{
     try{
-        const result = await axiosSession.get(BASE_URL + `houseworker/comments/${username}/${pageNumber}`);
+        const result = await authenticatedAxios.get(`/houseworker/comments/${username}/${pageNumber}`);
         const comms = result.data;
         return comms;
     }
@@ -90,7 +85,7 @@ export const getComments = async(username, pageNumber) =>{
 
 export const getUnreadComments = async(username) =>{
     try{
-        const result = await axiosSession.get(BASE_URL + `houseworker/comments/unread/${username}`);
+        const result = await authenticatedAxios.get(`/houseworker/comments/unread/${username}`);
         const comms = result.data;
         return comms;
     }
@@ -101,7 +96,7 @@ export const getUnreadComments = async(username) =>{
 
 export const markUnreadComments = async(username) =>{
     try{
-        const result = await axiosSession.get(BASE_URL + `houseworker/comments/unread/mark/${username}`);
+        const result = await authenticatedAxios.get(`/houseworker/comments/unread/mark/${username}`);
         const comms = result.data;
         return comms;
     }
@@ -112,7 +107,7 @@ export const markUnreadComments = async(username) =>{
 
 export const postComment = async(newComment) =>{
     try{
-        const result = await axiosSession.post(BASE_URL + `clients/comment`, newComment);
+        const result = await authenticatedAxios.post(`/clients/comment`, newComment);
         const commentResult = result.data;
         return commentResult;
     }catch(err){
@@ -122,10 +117,10 @@ export const postComment = async(newComment) =>{
 
 export const rateUser = async(rateObject) =>{
     try{
-        const postResult = await axiosSession.post(BASE_URL + 'clients/rate', rateObject)
+        const postResult = await authenticatedAxios.post('/clients/rate', rateObject)
         const postResultData = postResult.data;
         //fetch newRate(new calcuation of avarage rate)
-        const result = await axios.get(BASE_URL + `houseworker/rating/${rateObject.houseworker}`)
+        const result = await baseAxios.get(`/houseworker/rating/${rateObject.houseworker}`)
         const newAvgRate = result.data;
         
         // rate:rateValue, notification:notification  - postResult
@@ -136,10 +131,9 @@ export const rateUser = async(rateObject) =>{
     }
 }
 
-//axios default
 export const getRating = async(username) =>{
     try{
-        const result = await axios.get(BASE_URL + `houseworker/rating/${username}`)
+        const result = await baseAxios.get(`/houseworker/rating/${username}`)
         const ratingValue = result.data;
         return ratingValue;
     }
@@ -148,12 +142,11 @@ export const getRating = async(username) =>{
     }
 }
 
-//axios default
+
 //get all professions of the user(based on session.user ) 
 export const getProfessions = async()=>{
     try{
-        // const result = await axios.get(BASE_URL + `houseworker/professions/${username}`)
-        const result = await axios.get(BASE_URL + `houseworker/professions/`)
+        const result = await baseAxios.get(`/houseworker/professions/`)
         const professionsArray = result.data; 
         return professionsArray;
     }
@@ -162,10 +155,9 @@ export const getProfessions = async()=>{
     }
 }
 
-//axios default
 export const getProfessionsByUsername = async(username)=>{
     try{
-        const result = await axios.get(BASE_URL + `houseworker/professions/${username}`)
+        const result = await baseAxios.get(`/houseworker/professions/${username}`)
         const professionsArray = result.data; 
         return professionsArray;
     }
@@ -176,7 +168,7 @@ export const getProfessionsByUsername = async(username)=>{
 
 export const addProfession = async(label, working_hour) =>{
     try{
-        const result = await axios.post(BASE_URL +'houseworker/professions/add', {profession:label, working_hour:working_hour});
+        const result = await baseAxios.post('/houseworker/professions/add', {profession:label, working_hour:working_hour});
         return result;
     }
     catch(err){
@@ -186,7 +178,7 @@ export const addProfession = async(label, working_hour) =>{
 
 export const deleteProfession = async(profession) =>{
     try{
-        const result = await axios.delete(BASE_URL +`houseworker/professions/${profession}`);
+        const result = await baseAxios.delete(`/houseworker/professions/${profession}`);
         return result;
     }
     catch(err){
@@ -196,7 +188,7 @@ export const deleteProfession = async(profession) =>{
 
 export const getCommentsCount = async(username) =>{
     try{
-        const result = await axios.get(BASE_URL + `houseworker/comments/count/${username}`)
+        const result = await baseAxios.get(`/houseworker/comments/count/${username}`)
         const count = result.data;
         return count;
     }catch(err){
@@ -206,7 +198,7 @@ export const getCommentsCount = async(username) =>{
 
 export const getUnreadCommentsCount = async(username) =>{
     try{
-        const result = await axios.get(BASE_URL + `houseworker/comments/count/unread/${username}`)
+        const result = await baseAxios.get(`/houseworker/comments/count/unread/${username}`)
         const count = result.data;
         return count;
     }catch(err){
@@ -214,10 +206,9 @@ export const getUnreadCommentsCount = async(username) =>{
     }
 }
 
-//axios default
 export const getConversationCount = async(userRedisID) =>{
     try{
-        const result = await axios.get( BASE_URL + `chat/conversationCount/${userRedisID}`)
+        const result = await baseAxios.get(`/chat/conversationCount/${userRedisID}`)
         const count = result.data;
         return count;
     }
@@ -226,10 +217,9 @@ export const getConversationCount = async(userRedisID) =>{
     }
 }
 
-//axios default
 export const getAllCities = async() =>{
     try{
-        const result = await axios.get( BASE_URL + `houseworker/cities`);
+        const result = await baseAxios.get(`/houseworker/cities`);
         const cities = result.data;
         return cities;
     }
@@ -241,7 +231,7 @@ export const getAllCities = async() =>{
 //get all professions that exist(provided by houseworkers)
 export const getAllProfessions = async() =>{
     try{
-        const result = await axios.get(BASE_URL +`houseworker/professions/all`);
+        const result = await baseAxios.get(`/houseworker/professions/all`);
         const professionsResult = result.data;
         return professionsResult;
     }
@@ -250,10 +240,9 @@ export const getAllProfessions = async() =>{
     }
 }
 
-//axios default
 export const getHouseworkerByFilter = async(params) =>{
     try{
-        const result = await axios.get(BASE_URL + `houseworker/filter?${params}`);
+        const result = await baseAxios.get(`/houseworker/filter?${params}`);
         const houseworkers = result.data;
         return houseworkers;
     }
@@ -264,9 +253,8 @@ export const getHouseworkerByFilter = async(params) =>{
 
 export const getHomeInfo= async(username) =>{
     try{
-        const result = await axiosSession.get(BASE_URL + `houseworker/home/${username}`)
+        const result = await authenticatedAxios.get(`/houseworker/home/${username}`)
         const homeInfo = result.data;
-
         return homeInfo;
     }
     catch(err){
@@ -278,8 +266,8 @@ export const getHomeInfo= async(username) =>{
 export const getProfessionsAndCities = async() =>{
     try{
         const response = await axios.all([
-            await axios.get(BASE_URL +`houseworker/professions/all`),
-            await axios.get(BASE_URL + `houseworker/cities`)
+            await baseAxios.get('/houseworker/professions/all'),
+            await baseAxios.get('/houseworker/cities')
         ]);
         return {houseworker_professions: response[0].data, houseworker_cities: response[1].data}
     }
@@ -296,7 +284,7 @@ export const getProfessionsAndRating = async(username) =>{
         //     await axios.get(BASE_URL + `houseworker/rating/${username}`)
         // ])
         // return {professions:response[0].data, rating:response[1].data}
-        const result = await axios.get(BASE_URL + `houseworker/professionsandrating/${username}`)
+        const result = await baseAxios.get(`/houseworker/professionsandrating/${username}`)
         const houseworkerData = result.data;
 
         return {professions:houseworkerData.professions, rating:houseworkerData.avgRating}
@@ -309,7 +297,7 @@ export const getProfessionsAndRating = async(username) =>{
 
 export const getNotifications = async(username) =>{
     try{
-        const result = await axiosSession.get(BASE_URL + `houseworker/notifications/${username}?offset=0&size=6`)
+        const result = await authenticatedAxios.get(`/houseworker/notifications/${username}?offset=0&size=10`)
         const notifications = result.data;
         return notifications;
     }
@@ -320,7 +308,7 @@ export const getNotifications = async(username) =>{
 
 export const getMoreNotifications = async(username, batchNumber) =>{
     try{
-        const result = await axiosSession.get(BASE_URL + `houseworker/notifications/${username}/${batchNumber}`)
+        const result = await authenticatedAxios.get(`/houseworker/notifications/${username}/${batchNumber}`)
         const notifications = result.data;
         return notifications;
     }
@@ -331,7 +319,7 @@ export const getMoreNotifications = async(username, batchNumber) =>{
 
 export const markNotificationAsRead = async(notificationID, batchNumber) =>{
     try{
-        await axiosSession.put(BASE_URL + `houseworker/notifications/mark/`, {notificationID, batchNumber})
+        await authenticatedAxios.put(`/houseworker/notifications/mark/`, {notificationID, batchNumber})
     }
     catch(err){
         ThrowErorr(err);

--- a/client/src/utils/AxiosConfig.js
+++ b/client/src/utils/AxiosConfig.js
@@ -2,16 +2,25 @@ import axios from "axios"
 import { sessionExpired } from "../store/auth-slice";
 import { resetReduxStates } from "../store/reset-states";
 
-export const axiosSession = axios.create({
-    withCredentials:true,
+const BASE_URL =
+  process.env.NODE_ENV === 'production'   
+    ? 'https://homeassistant-ed5z.onrender.com/api'        
+    : 'http://localhost:5000/api';
+
+
+export const baseAxios = axios.create({
+    baseURL: BASE_URL
 })
 
+export const authenticatedAxios = axios.create({
+    baseURL: BASE_URL,
+    withCredentials:true
+})
 
-export const requestInterceptor = (dispatch) => axiosSession.interceptors.response.use(
+export const requestInterceptor = (dispatch) => authenticatedAxios.interceptors.response.use(
     response => {return response},
     (error) =>{
         //401 status on not authenticated users (when is session expired server will return 401 status)
-
         if(error.response.status === 401){
             //reset all redux states
             resetReduxStates(dispatch);
@@ -22,7 +31,6 @@ export const requestInterceptor = (dispatch) => axiosSession.interceptors.respon
     
         //don't logout(removeSession) on not Authorized request
         if(error.response.status === 403){
-            //logic
             return Promise.reject(error);
         }
 


### PR DESCRIPTION
### Description
- Replaced old axiosInterceptors.js with new axiosConfig.js
- Added `BASE_URL` that switches between production (Render hosted API) and local development
- Created two axios instances:
  - `baseAxios` (no credentials, general requests)
  - `authenticatedAxios` (withCredentials: true, protected routes)
- Updated service files (auth.js, chat.js, client.js, houseworker.js) to use new axios instances