### PR TITLE
Optimize Messages page to prevent unnecessary re-rendering 

### DIFF
--- a/client/src/components/Chat/Room.js
+++ b/client/src/components/Chat/Room.js
@@ -1,11 +1,11 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, memo } from 'react';
 import Photo from '../../utils/Photo';
 import GroupsIcon from '@mui/icons-material/Groups';
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
 
 import '../../sass/components/_room.scss';
 
-const Room = ({
+const Room = memo(({
     info, 
     roomInfo, 
     unreadItem, 
@@ -39,98 +39,103 @@ const Room = ({
         }
     },[isActive, roomsContainerRef]);
 
+
     return(
         <>
-            {info.users.length > 1 
-            ?
-            <div ref={isActive ? activeRoomRef : null} className={`room group ${isActive} ${unreadItem? 'unread' : ''}`} >
-            {unreadCount &&     
-            <div className='unread-mess'>
-                <div className='unread-mess-count'>{unreadCount}</div>
-            </div>
-            }
-            <div className={`group-sign ${isActive}-icon`}><GroupsIcon/></div>
-            <button className='handler-surface' value={info.roomID} onClick={onRoomClickHanlder} />
-                <div className ='user-photo-container'>
-                    {moreRoomUsers?.users && moreRoomUsers.roomID == info.roomID &&
-                        <div className='more-user-chat-container'>
-                            {moreRoomUsers.users.map(el =>{
-                                return(
-                                    <div className='user-chat-label' key={`e-${el.username}`}>
-                                        {el.online && <div className='online-user'></div>}
-                                        <div>{el.username}</div>
-                                    </div>
-                                )
-                            })
-                            }
+            {info.users.length > 1
+                ?
+                <div ref={isActive ? activeRoomRef : null} className={`room group ${isActive} ${unreadItem ? 'unread' : ''}`} >
+                    {unreadCount &&
+                        <div className='unread-mess'>
+                            <div className='unread-mess-count'>{unreadCount}</div>
                         </div>
                     }
-                    {/* for group room display user avatar with name and potential online status  */}
-                    {info.users.length > 3 
-                    ?
-                    <> 
-                        {info.users.slice(0,3).map((user) => 
-                            {
-                                return(
-                                    <Photo
-                                        key={`u-${user.username}`}
-                                        username={user.username}
-                                        picturePath={user.picturePath}
-                                        online={user.online}
-                                    />
-                                )
-                            })}
-                        <div className="more-user">
-                            <div className ='more-user-icon' onMouseEnter={() => onShowMoreUsersFromChatHandler({roomID:info.roomID, users:info.users.slice(3)})} onMouseLeave={() => onUsersFromChatOutHanlder()}> 
-                                <MoreHorizIcon/>    
+                    <div className={`group-sign ${isActive}-icon`}><GroupsIcon /></div>
+                    <button className='handler-surface' value={info.roomID} onClick={onRoomClickHanlder} />
+                    <div className='user-photo-container'>
+                        {moreRoomUsers?.users && moreRoomUsers.roomID == info.roomID &&
+                            <div className='more-user-chat-container'>
+                                {moreRoomUsers.users.map(el => {
+                                    return (
+                                        <div className='user-chat-label' key={`e-${el.username}`}>
+                                            {el.online && <div className='online-user'></div>}
+                                            <div>{el.username}</div>
+                                        </div>
+                                    )
+                                })
+                                }
                             </div>
+                        }
+                        {/* for group room display user avatar with name and potential online status  */}
+                        {info.users.length > 3 
+                        ?
+                        <> 
+                            {info.users.slice(0,3).map((user) => 
+                                {
+                                    return(
+                                        <Photo
+                                            key={`u-${user.username}`}
+                                            username={user.username}
+                                            picturePath={user.picturePath}
+                                            online={user.online}
+                                        />
+                                    )
+                                })}
+                            <div className="more-user">
+                                <div 
+                                    className ='more-user-icon' 
+                                    onMouseEnter={() => onShowMoreUsersFromChatHandler({roomID:info.roomID, users:info.users.slice(3)})} 
+                                    onMouseLeave={() => onUsersFromChatOutHanlder()}
+                                > 
+                                    <MoreHorizIcon/>    
+                                </div>
+                            </div>
+                        </>
+                        :
+                        <>
+                            {info.users.map((user) => 
+                                {
+                                    return(
+                                        <Photo
+                                            key={`us-${user.username}`}
+                                            username={user.username}
+                                            picturePath={user.picturePath}
+                                            online={user.online}
+                                        />
+                                    )
+                                }
+                            )}
+                        </>
+                        }
+                    </div>
+                    <div className={`timer ${info.users.length === 4 ? 'timer-bottom' : ''} `}>{info.lastMessage?.dateDiff || "just now"}</div>
+                </div>
+
+                :  
+                
+                <div className={`room ${isActive} ${unreadCount ? 'unread' : ''}`}>   
+                    <button className='handler-surface' value={info.roomID} onClick={onRoomClickHanlder} />
+                    {unreadCount &&
+                    <div className='unread-mess'>
+                        <div className='unread-mess-count'>{unreadCount}</div>
+                    </div>
+                    }     
+                    {/* If private then show profile picture with name desk */}       
+                    <div className='room-info'>
+                        <div className="photo" style={{backgroundImage: `url(${info.users[0].picturePath})`}}>
+                            {info.users[0].online && <div className="online"></div>} 
                         </div>
-                    </>
-                    :
-                    <>
-                        {info.users.map((user) => 
-                            {
-                                return(
-                                    <Photo
-                                        key={`us-${user.username}`}
-                                        username={user.username}
-                                        picturePath={user.picturePath}
-                                        online={user.online}
-                                    />
-                                )
-                            }
-                        )}
-                    </>
-                    }
-                </div>
-                <div className={`timer ${info.users.length === 4 ? 'timer-bottom' : ''} `}>{info.lastMessage?.dateDiff || "just now"}</div>
-                {/* <div className='unread-mess-count'>{unreadCount}</div> */}
-            </div>
-            :  
-            <div className={`room ${isActive} ${unreadCount ? 'unread' : ''}`}>   
-                <button className='handler-surface' value={info.roomID} onClick={onRoomClickHanlder} />
-                {unreadCount &&
-                <div className='unread-mess'>
-                    <div className='unread-mess-count'>{unreadCount}</div>
-                </div>
-                }
-                {/* IF PRIVATE THAT SHOW PROFILE PICTURE WITH NAME DESK */}       
-                <div className='room-info'>
-                    <div className="photo" style={{backgroundImage: `url(${info.users[0].picturePath})`}}>
-                        {info.users[0].online && <div className="online"></div>} 
+                        <div className="room-contact">
+                            <p className="name">Name: {info.users[0].username}</p>
+                            <p className="message">{info.lastMessage.message}</p>
+                        </div>
                     </div>
-                    <div className="room-contact">
-                        <p className="name">Name: {info.users[0].username}</p>
-                        <p className="message">{info.lastMessage.message}</p>
-                    </div>
+                    <div className="timer">{info.lastMessage.dateDiff}</div>
                 </div>
-                <div className="timer">{info.lastMessage.dateDiff}</div>
-                {/* <div>{unreadCount}</div> */}
-            </div>
-        }
+            }
         </>
     )
-}
+})
 
 
 export default Room;

--- a/client/src/components/Chat/Rooms.js
+++ b/client/src/components/Chat/Rooms.js
@@ -1,37 +1,44 @@
-import {useRef} from 'react';
+import {useRef, memo, useMemo} from 'react';
 import Spinner from '../../components/UI/Spinner.js';
 import Room from "./Room.js";
 import {useSelector} from 'react-redux';
 
-const Rooms = ({rooms, roomInfo, showMoreRoomUsers, onRoomClickHanlder, onShowMoreUsersFromChatHandler, onUsersFromChatOutHanlder}) =>{
+const Rooms = memo(({rooms, roomInfo, showMoreRoomUsers, onRoomClickHanlder, onShowMoreUsersFromChatHandler, onUsersFromChatOutHanlder}) =>{
     const {unreadMessages} = useSelector((state) => state.unreadMessages);
     const roomsContainerRef = useRef(null);
 
+    //dispaly only more users of hovered room (that prevent to all Rooms be re-rendered)
+    const activeShowUsers = useMemo(() => showMoreRoomUsers, [showMoreRoomUsers.roomID]) //rooms only re-render when the roomID changes
+
+    const roomsList = useMemo(() => {
+        if(!rooms || rooms.length === 0) return null;
+
+        return rooms.map(el => {
+            const unreadItem = unreadMessages.find(
+                (item) => item.roomID === el.roomID
+            );
+
+            return(
+                <Room
+                    key={`room-${el.roomID}`}
+                    info={el}
+                    unreadItem={unreadItem}
+                    roomInfo={roomInfo}
+                    moreRoomUsers={activeShowUsers}
+                    onRoomClickHanlder={onRoomClickHanlder}
+                    onShowMoreUsersFromChatHandler={onShowMoreUsersFromChatHandler}
+                    onUsersFromChatOutHanlder={onUsersFromChatOutHanlder}
+                    roomsContainerRef={roomsContainerRef}
+                />
+            )
+        })
+    },[rooms, roomInfo, unreadMessages, activeShowUsers, onRoomClickHanlder, onShowMoreUsersFromChatHandler, onUsersFromChatOutHanlder]);
+
     return(
             <div className='rooms' ref={roomsContainerRef}>
-                {rooms ?
-                    rooms.map(el =>{      
-                        const unreadItem = Object.values(unreadMessages).find(
-                            (item) => item.roomID === el.roomID
-                        );
-                        return(
-                            <Room
-                                key={`room-${el.roomID}`}
-                                info={el}
-                                unreadItem={unreadItem}
-                                roomInfo={roomInfo}
-                                moreRoomUsers={showMoreRoomUsers}
-                                onRoomClickHanlder={onRoomClickHanlder}
-                                onShowMoreUsersFromChatHandler={onShowMoreUsersFromChatHandler}
-                                onUsersFromChatOutHanlder={onUsersFromChatOutHanlder}
-                                roomsContainerRef={roomsContainerRef}
-                            />
-                        )
-                    })
-                : <Spinner/>
-                }
+                {rooms ? roomsList : <Spinner/>}
             </div>
     )
-}
+});
 
 export default Rooms;

--- a/client/src/components/MessagesReducer.js
+++ b/client/src/components/MessagesReducer.js
@@ -121,6 +121,17 @@ export const MessagesReducer = (state, action) =>{
                     return room;
                 })
             };
+        case "UPDATE_ONLINE_STATUS":
+            return {
+                ...state,
+                rooms: state.rooms.map(room => ({
+                    ...room,
+                    users: room.users.map(user => ({
+                        ...user,
+                        online: state.onlineUsers.includes(user.userID)
+                    }))
+                }))
+            };
         case "KICK_USER_FROM_GROUP":
             return{
                 ...state,

--- a/client/src/hooks/useMessages.js
+++ b/client/src/hooks/useMessages.js
@@ -1,4 +1,4 @@
-import {useReducer, useState, useRef, useEffect} from "react";
+import {useReducer, useState, useRef, useEffect, useCallback} from "react";
 import {useDispatch, useSelector} from 'react-redux';
 import {toast} from 'react-toastify';
 import {handlerError} from "../utils/ErrorUtils.js";
@@ -11,7 +11,10 @@ import {resetUserUnreadMessagesCount, resetUsersUnreadMessagesbyRoomID, forwardU
 import {setCurrentRoom, clearCurrentRoom} from "../store/currentRoomSlice.js";
 import {sendMessage} from "../utils/MessageUtils/handleMessage.js";
 
+//COMMIT: Optimized to precent Rooms re-rendering on typingNotification receving, on Opening Menu options
+
 const useMessages = (socket, user) =>{
+
     const initialState = {
         loading:true,
         rooms:[],
@@ -33,16 +36,52 @@ const useMessages = (socket, user) =>{
     const {unreadMessages} = useSelector((state) => state.unreadMessages);
     const reduxDispatch = useDispatch();
 
-    const onShowMenuToggleHandler = () =>  setShowMenu(prev => !prev);
-    const onUsersFromChatOutHanlder = () => setShowMoreRoomUsers({});
+    const onShowMenuToggleHandler = () => {
+        setShowMenu(prev => !prev);
+    }
+    const onUsersFromChatOutHanlder = useCallback(() => {
+        setShowMoreRoomUsers({})
+    },[]);
 
-    const onAddTypingUserHandler = (userInfo) =>{
+
+    const onAddTypingUserHandler = useCallback((userInfo) =>{
         dispatch({type:"SET_TYPING_USER", data:userInfo});
-    }
+    }, []);
 
-    const onRemoveTypingUserHandler = (userInfo) =>{
+    const onRemoveTypingUserHandler = useCallback((userInfo) =>{
         dispatch({type:"REMOVE_TYPING_USER", data:userInfo});
-    }
+    }, []);
+
+    const enterRoomAfterAction = useCallback(async(roomID, read) =>{
+        //don't applie logic if is clicked on the same room
+        if(roomID === state.roomInfo.roomID)
+                return;
+        try{
+            if(read)
+                reduxDispatch(resetUserUnreadMessagesCount({roomID, userID:user.userID}))
+        
+            pageNumberRef.current = 0; //reset page number on entering new room
+
+            if(state.roomInfo.roomID !='' && state.roomInfo.roomID != roomID){
+                emitLeaveRoom(socket, state.roomInfo.roomID);
+                reduxDispatch(clearCurrentRoom());
+            }
+
+            emitRoomJoin(socket, roomID);
+
+            setIsLoadingMessages(true);
+            const messages = await getMessagesByRoomID(roomID);
+            dispatch({type:"SET_ROOM_MESSAGE_WITH_ROOM_INFO", messages:messages, ID:roomID})
+            reduxDispatch(setCurrentRoom({currentRoomID: roomID}))
+            setIsLoadingMessages(false);
+
+            if(showMenu)
+                setShowMenu(false);
+        }
+        catch(err){
+            handlerError(err); 
+        }
+    },[socket, reduxDispatch])
 
     useEffect(() => {
         if(socket && user){
@@ -56,8 +95,32 @@ const useMessages = (socket, user) =>{
             listenOnKickUserFromGroup(socket, dispatch, user.userID);
             listenOnKickUserFromGroupInRoom(socket, user.userID, enterRoomAfterAction);
             listenNewOnlineUser(socket, dispatch, user.userID);
+
+            //Typing listeners
+            const handleTypingStart = (sender) => {
+                const {senderID, senderUsername} = sender;
+                if(senderID == user.userID) return;
+                onAddTypingUserHandler({userID:senderID, username:senderUsername}); 
+            }
+
+            const handleTypingStop = (sender) => {
+                const {senderID, senderUsername} = sender;
+                if(senderID == user.userID) return;
+                onRemoveTypingUserHandler({userID:senderID, username:senderUsername});
+            }
+
+
+            socket.on("typingMessageStart", handleTypingStart);
+            socket.on("typingMessageStop", handleTypingStop);
+
+
+            return () => {
+                socket.off("typingMessageStart", handleTypingStart);
+                socket.off("typingMessageStop", handleTypingStop);
+            };
+
         }
-    },[socket])
+    },[socket, user]) 
 
     useEffect(() => {
         currentRoomIDRef.current = state.roomInfo?.roomID || null;
@@ -74,7 +137,7 @@ const useMessages = (socket, user) =>{
         };
     }, []);
 
-    const fetchMoreMessages = (async (roomID, pageNumber) =>{
+    const fetchMoreMessages = async (roomID, pageNumber) =>{
         try{
             const messages = await getMoreMessagesByRoomID(roomID, pageNumber);
 
@@ -85,9 +148,9 @@ const useMessages = (socket, user) =>{
         catch(err){
             handlerError(err);
         }
-    })
+    }
 
-    const fetchAllRooms = (async () =>{  
+    const fetchAllRooms = useCallback(async () =>{  
         try{
             const data = await getUserRooms(user.username); //roomID, users{}
             dispatch({type:"SET_ROOMS", data:data.rooms}) 
@@ -118,9 +181,9 @@ const useMessages = (socket, user) =>{
         catch(err){
             handlerError(err);
         }
-    });
+    },[socket, reduxDispatch, unreadMessages]);
 
-    const getAllHouseworkers = async() =>{
+    const getAllHouseworkers = useCallback(async() =>{
         try{
             const houseworkerResult = await getHouseworkers();
             dispatch({type:"SET_HOUSEWORKERS", data:houseworkerResult});
@@ -128,9 +191,9 @@ const useMessages = (socket, user) =>{
         catch(err){
             handlerError(err);
         }
-    }
+    },[])
 
-    const getOnlineChatUsers = async() =>{
+    const getOnlineChatUsers = useCallback(async() =>{
         try{
             const onlineUsers = await getOnlineUsers(user.userID);
             dispatch({type:"SET_ONLINE_USER", data:onlineUsers});
@@ -138,48 +201,15 @@ const useMessages = (socket, user) =>{
         catch(err){
             handlerError(err);
         }
-    }
+    },[])
 
-    const getOnlineUserStatus = (userID) =>{
+    const getOnlineUserStatus = useCallback((userID) =>{
         const status = state.onlineUsers.includes(userID);
         return status;
-    }
-    
-    const enterRoomAfterAction = async(roomID, read) =>{
-        try{
-            if(read)
-                reduxDispatch(resetUserUnreadMessagesCount({roomID, userID:user.userID}))
-        
-            //don't applie logic if is clicked on the same room
-            if(roomID === state.roomInfo.roomID)
-                return;
+    },[state.onlineUsers])
 
-            pageNumberRef.current = 0; //reset page number on entering new room
 
-            if(state.roomInfo.roomID !='' && state.roomInfo.roomID != roomID){
-                emitLeaveRoom(socket, state.roomInfo.roomID);
-                reduxDispatch(clearCurrentRoom());
-            }
-
-            emitRoomJoin(socket, roomID);
-
-            setIsLoadingMessages(true);
-            const messages = await getMessagesByRoomID(roomID);
-            dispatch({type:"SET_ROOM_MESSAGE_WITH_ROOM_INFO", messages:messages, ID:roomID})
-            reduxDispatch(setCurrentRoom({currentRoomID: roomID}))
-
-            // reduxDispatch(resetUserUnreadMessagesCount({roomID, userID:user.userID}))
-            setIsLoadingMessages(false);
-
-            if(showMenu)
-                setShowMenu(false);
-        }
-        catch(err){
-            handlerError(err); 
-        }
-    }
-
-    const onRoomClickHanlder = ( async e =>{
+    const onRoomClickHanlder = useCallback(async (e) =>{
         const roomID = e.target.value;
         try{
             await enterRoomAfterAction(roomID, true);
@@ -188,9 +218,9 @@ const useMessages = (socket, user) =>{
         catch(err){
             handlerError(err);
         }
-    })
+    },[enterRoomAfterAction]);
 
-    const onDeleteRoomHandler = async(e) => {   
+    const onDeleteRoomHandler = useCallback(async(e) => {   
         const roomID = e.target.value;
         try{
             const notifications = await deleteRoom(roomID);
@@ -213,7 +243,7 @@ const useMessages = (socket, user) =>{
         catch(err){
             handlerError(err);
         }
-    }
+    },[socket, reduxDispatch])
 
     useEffect(()=>{
         //onDelete function for deleting room from state.rooms (is Async)
@@ -241,9 +271,9 @@ const useMessages = (socket, user) =>{
             }
             dispatch({type:"RESET_ROOM_ACTION"});
         }
-    },[state.rooms])
+    },[state.rooms, state.roomsAction, socket, reduxDispatch, enterRoomAfterAction])
 
-    const MessagesAfterRoomsAction = async(roomID)=>{
+    const MessagesAfterRoomsAction = useCallback(async(roomID)=>{
         try{
             const messages = await getMessagesByRoomID(roomID)
             dispatch({type:"SET_ROOM_MESSAGE_WITH_ROOM_INFO", messages:messages, ID:roomID});
@@ -252,27 +282,26 @@ const useMessages = (socket, user) =>{
         catch(err){
             handlerError(err);
         }
-    }
+    },[]);
 
     useEffect(() =>{
         fetchAllRooms();
         getAllHouseworkers();
         getOnlineChatUsers();
-    },[])
+    // },[])
+    }, [fetchAllRooms, getAllHouseworkers, getOnlineChatUsers]);
 
-    const showNewOnlineUsers = async() =>{
+    const showNewOnlineUsers = useCallback(async() =>{
         const data = await getUserRooms(user.username); //roomID, users{}) 
         dispatch({type:"SET_ROOMS", data:data.rooms}) 
-    }
+    },[])
 
-    useEffect(() =>{
-        //triger re-rendering the rooms (only when the new online user exist) and chat view but   
-        //don't override roomInfo: current visited chat
-        showNewOnlineUsers()
-    },[state.onlineUsers]) //has changed in socketListener
+    useEffect(() => {
+        if (!state.onlineUsers.length || !state.rooms.length) return;
+        dispatch({ type: "UPDATE_ONLINE_STATUS" });
+    }, [state.onlineUsers]);
 
-
-    const onAddUserToGroupHanlder = (async(roomID, username)=>{
+    const onAddUserToGroupHanlder = useCallback(async(roomID, username)=>{
         if(username == ""){
             toast.info("Select user that you want to add in room",{
                 className:"toast-contact-message"
@@ -300,19 +329,43 @@ const useMessages = (socket, user) =>{
 
             const onlineStatus = getOnlineUserStatus(newUserID);
             
-            const groupData = {newUserID, newUsername:username, roomID, newRoomID, currentMember:currentUser, clientID:user.userID ,clientUsername:user.username, newUserPicturePath, online:onlineStatus, notifications};
+            const groupData = {
+                newUserID, 
+                newUsername:username, 
+                roomID, newRoomID, 
+                currentMember:currentUser, 
+                clientID:user.userID,
+                clientUsername:user.username, 
+                newUserPicturePath, 
+                online:onlineStatus, 
+                notifications};
             if(isPrivate){              
                 emitCreteUserGroup(socket, {data:groupData});
                 //check newUserID in onlineUsers state
                 //update client room view
-                dispatch({type:"CREATE_NEW_GROUP" , roomID:roomID, newRoomID:newRoomID, currentMember:currentUser, newUserID:newUserID, newUsername:username, picturePath:newUserPicturePath, online:onlineStatus})
+                dispatch({ type:"CREATE_NEW_GROUP", 
+                    roomID:roomID, 
+                    newRoomID:newRoomID, 
+                    currentMember:currentUser, 
+                    newUserID:newUserID, 
+                    newUsername:username, 
+                    picturePath:newUserPicturePath, 
+                    online:onlineStatus
+                })
                 toast.info("A Group with "+ username + " has been created");
                 //Scroll to bottom(new added room)
             }
             else{ 
                 // const groupData = {newUserID, newUsername:username, roomID, newRoomID, currentMember:currentUser, clientID:user.userID ,clientUsername:user.username, newUserPicturePath, online:onlineStatus, notifications};
                 emitUserAddedToChat(socket, {data:groupData});       
-                dispatch({type:"ADD_USER_TO_GROUP", roomID:roomID, newRoomID:newRoomID, newUserID:newUserID, newUsername:username, picturePath:newUserPicturePath, online:onlineStatus});
+                dispatch({ type:"ADD_USER_TO_GROUP", 
+                    roomID:roomID, 
+                    newRoomID:newRoomID,
+                    newUserID:newUserID, 
+                    newUsername:username, 
+                    picturePath:newUserPicturePath, 
+                    online:onlineStatus
+                });
                 toast.info("User is added to the room: "+  newRoomID);
             }
 
@@ -321,9 +374,9 @@ const useMessages = (socket, user) =>{
         catch(err){
             handlerError(err);
         }
-    });
+    },[state.rooms, socket, user.userID, user.username, enterRoomAfterAction]);
 
-    const onKickUserFromGroupHandler = async(roomID, username) =>{
+    const onKickUserFromGroupHandler = useCallback(async(roomID, username) =>{
         if(username == ""){
             toast.error("Select user that you want to kick from room",{
                 className:"toast-contact-message"
@@ -355,9 +408,9 @@ const useMessages = (socket, user) =>{
         catch(err){
             handlerError(err);
         }
-    }
+    },[socket, reduxDispatch, enterRoomAfterAction])
 
-    const onSendMessageHandler = async({message, fromRoomID}) =>{        
+    const onSendMessageHandler = useCallback(async({message, fromRoomID}) =>{        
         if(message != ''){
             const messageObj = {
                 message:message,
@@ -386,10 +439,13 @@ const useMessages = (socket, user) =>{
             toast.error("Empty message cannot be sent",{
                 className:'toast-contact-message'
             })
-    }
+    },[socket, unreadMessages, reduxDispatch])
 
-    const onShowMoreUsersFromChatHandler = ({roomID, users}) => setShowMoreRoomUsers({roomID, users});
-    const onShowRoomsButtonHandler = () => {setShowChatView(false)}
+    const onShowMoreUsersFromChatHandler = useCallback(({roomID, users}) => 
+        setShowMoreRoomUsers({roomID, users})
+    ,[]);
+
+    const onShowRoomsButtonHandler = () => useCallback(() => {setShowChatView(false)}, []);
 
     return {
         state, 

--- a/client/src/hooks/useTyping.js
+++ b/client/src/hooks/useTyping.js
@@ -1,7 +1,6 @@
-import {useState, useEffect, useRef} from 'react';
+import {useState, useEffect, useRef, useCallback} from 'react';
 
 const useTyping = (startTypingMessageSendEmit, stopTypingMessageEmit) =>{
-    
     const [isTyping, setIsTyping] = useState(false);
     const [isKeyPressed, setIsKeyPressed] = useState(false);
     const cooldownRef = useRef(0);
@@ -29,7 +28,7 @@ const useTyping = (startTypingMessageSendEmit, stopTypingMessageEmit) =>{
         return () => clearInterval(interval);
     }, [isTyping, stopTypingMessageEmit])
 
-    const startTypingHandler = () =>{
+    const startTypingHandler = useCallback(() =>{
         //inovoked on every key press
         if(!isKeyPressed && !isTyping){
             setIsKeyPressed(true);
@@ -37,15 +36,17 @@ const useTyping = (startTypingMessageSendEmit, stopTypingMessageEmit) =>{
             setIsTyping(true);
             startTypingMessageSendEmit();
         }
-    }
+    },[isKeyPressed, isTyping, startTypingMessageSendEmit])
 
-    const stopTypingOnSendMessage = () =>{
+    const stopTyping = useCallback(() =>{
         setIsTyping(false);
         setIsKeyPressed(false);
         cooldownRef.current = 0;
-    }
+        stopTypingMessageEmit();
+    },[stopTypingMessageEmit])
 
-    return {isTyping, isKeyPressed, cooldownRef, startTypingHandler, stopTypingOnSendMessage}
+
+    return {isTyping, isKeyPressed, cooldownRef, startTypingHandler, stopTyping}
 }
 
 

--- a/client/src/pages/Messages.js
+++ b/client/src/pages/Messages.js
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, memo } from 'react';
 import {useSelector} from 'react-redux';
 import useMessages from '../hooks/useMessages';
 import Chat from '../components/Chat/Chat.js';
@@ -7,8 +7,7 @@ import Spinner from '../components/UI/Spinner.js';
 
 import '../sass/pages/_messages.scss';
 
-const Messages = ({socket, connected}) =>{
-    
+const Messages = memo(({socket}) =>{
     const {user} = useSelector((state) => state.auth)
     const {
         state, 
@@ -19,8 +18,6 @@ const Messages = ({socket, connected}) =>{
         pageNumberRef,
         onShowMenuToggleHandler,
         onUsersFromChatOutHanlder,
-        onAddTypingUserHandler, 
-        onRemoveTypingUserHandler,
         fetchMoreMessages,
         onRoomClickHanlder,
         onDeleteRoomHandler,
@@ -30,7 +27,6 @@ const Messages = ({socket, connected}) =>{
         onShowMoreUsersFromChatHandler,
         onShowRoomsButtonHandler
     } = useMessages(socket, user);
-
 
     useEffect(() => {
         document.body.style.overflow = 'hidden';
@@ -51,7 +47,6 @@ const Messages = ({socket, connected}) =>{
                 <Rooms 
                     rooms={state.rooms}
                     roomInfo={state.roomInfo}
-                    unread={state.unreadMessages}
                     showMoreRoomUsers={showMoreRoomUsers}
                     onRoomClickHanlder={onRoomClickHanlder}
                     onShowMoreUsersFromChatHandler={onShowMoreUsersFromChatHandler}
@@ -75,8 +70,6 @@ const Messages = ({socket, connected}) =>{
                     onDeleteRoomHandler={onDeleteRoomHandler}
                     onShowMenuToggleHandler={onShowMenuToggleHandler}
                     fetchMoreMessages={fetchMoreMessages}
-                    onAddTypingUserHandler={onAddTypingUserHandler}
-                    onRemoveTypingUserHandler={onRemoveTypingUserHandler}
                 />
                 
             </section>
@@ -84,7 +77,7 @@ const Messages = ({socket, connected}) =>{
         }
     </div>
     )
-}
+});
 
 export default Messages;
 


### PR DESCRIPTION
### Summary
- Optimized Messages page performance by implementing React memoization patterns and centralizing socket listeners, reducing unnecessary re-renders during typing notifications, online status changing and menu interactions.

### Changes
- Wrapped all event handlers in `useMessages` with `useCallback` to stabilize component references
- Moved typing socket listeners from Chat component to useMessages hook for centralized management
- Added `React.memo()` to Chat, ChatMenu, Rooms, and Room components with custom comparison logic
- Implemented `useMemo` for filtered user lists in ChatMenu (houseworkers and kick users)
- Replaced redundant `showNewOnlineUsers()` API call with new created  `UPDATE_ONLINE_STATUS` reducer action
- Added stopTypingMessageEmit prop function in useTyping hook and renaming it from `stopTypingOnSendMessage` to `stopTyping`
